### PR TITLE
feat(context-mcp): initialize context-mcp package with core setup

### DIFF
--- a/packages/context-mcp/.eslintrc.json
+++ b/packages/context-mcp/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+} 

--- a/packages/context-mcp/.gitignore
+++ b/packages/context-mcp/.gitignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules/
+.pnp/
+.pnp.js
+
+# Build outputs
+dist/
+build/
+*.tsbuildinfo
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# IDE and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Cache
+.cache/
+.temp/
+.tmp/
+.eslintcache
+.stylelintcache
+
+# Package files
+*.tgz
+*.zip
+*.tar.gz

--- a/packages/context-mcp/.npmignore
+++ b/packages/context-mcp/.npmignore
@@ -1,0 +1,37 @@
+# Source files
+src/
+__tests__/
+test/
+tests/
+*.test.ts
+*.spec.ts
+
+# Development configs
+.eslintrc*
+.prettierrc*
+.editorconfig
+.gitignore
+.git/
+.github/
+.vscode/
+.idea/
+*.log
+
+# Build configs
+rollup.config.js
+tsconfig.json
+jest.config.js
+
+# Development dependencies
+node_modules/
+
+# Misc
+.DS_Store
+*.tgz
+*.zip
+*.tar.gz
+coverage/
+.nyc_output/
+.cache/
+.temp/
+.tmp/ 

--- a/packages/context-mcp/README.md
+++ b/packages/context-mcp/README.md
@@ -1,0 +1,49 @@
+# @autodev/context-mcp
+
+Model Context Protocol implementation for AutoDev.
+
+## Installation
+
+```bash
+npm install @autodev/context-mcp
+# or
+yarn add @autodev/context-mcp
+# or
+pnpm add @autodev/context-mcp
+```
+
+## Usage
+
+```typescript
+import { MCPClient, MCPServer } from "@autodev/context-mcp";
+
+// Create a client
+const client = new MCPClient({
+  // configuration options
+});
+
+// Create a server
+const server = new MCPServer({
+  // configuration options
+});
+```
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run linter
+pnpm lint
+```
+
+## License
+
+MIT

--- a/packages/context-mcp/index.js
+++ b/packages/context-mcp/index.js
@@ -1,1 +1,0 @@
-console.log('context-mcp');

--- a/packages/context-mcp/jest.config.js
+++ b/packages/context-mcp/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/__tests__/**/*.ts", "**/?(*.)+(spec|test).ts"],
+  transform: {
+    "^.+\\.ts$": "ts-jest",
+  },
+  moduleFileExtensions: ["ts", "js", "json", "node"],
+};

--- a/packages/context-mcp/package.json
+++ b/packages/context-mcp/package.json
@@ -1,15 +1,58 @@
 {
   "name": "@autodev/context-mcp",
   "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "description": "Model Context Protocol implementation",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
-  "keywords": [],
-  "author": "",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "test": "jest",
+    "lint": "eslint src --ext .ts,.tsx",
+    "clean": "rimraf dist",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "typescript"
+  ],
+  "author": "AutoDev authors",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.5",
+    "rollup": "^4.12.0",
+    "rollup-plugin-dts": "^6.1.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.3.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/context-mcp/rollup.config.js
+++ b/packages/context-mcp/rollup.config.js
@@ -1,0 +1,44 @@
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import typescript from "@rollup/plugin-typescript";
+import json from "@rollup/plugin-json";
+import dts from "rollup-plugin-dts";
+import { defineConfig } from "rollup";
+
+const packageJson = require("./package.json");
+
+export default defineConfig([
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: packageJson.main,
+        format: "cjs",
+        sourcemap: true,
+      },
+      {
+        file: packageJson.module,
+        format: "esm",
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      resolve(),
+      commonjs(),
+      json(),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        exclude: ["**/__tests__/**", "**/*.test.ts"],
+      }),
+    ],
+    external: [
+      ...Object.keys(packageJson.dependencies || {}),
+      ...Object.keys(packageJson.peerDependencies || {}),
+    ],
+  },
+  {
+    input: "dist/types/index.d.ts",
+    output: [{ file: "dist/index.d.ts", format: "esm" }],
+    plugins: [dts()],
+  },
+]);

--- a/packages/context-mcp/src/index.ts
+++ b/packages/context-mcp/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./client";
+export * from "./server";

--- a/packages/context-mcp/tsconfig.json
+++ b/packages/context-mcp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+} 


### PR DESCRIPTION
- Initialize @autodev/context-mcp package with core setup  
- Configure TypeScript, Rollup build, and Jest testing support  
- Export types, client, and server modules from source  
- Add README with installation and usage instructions  
- Configure .gitignore and .npmignore to exclude build artifacts and dev files  
- Set up package.json with metadata, scripts (build, test, lint, clean), and dependencies