### PR TITLE
feat(context-mcp): add MCP client and server scaffolding implementations

### DIFF
--- a/packages/context-mcp/src/client.ts
+++ b/packages/context-mcp/src/client.ts
@@ -1,0 +1,50 @@
+import { ContextRequest, ContextResponse } from "@modelcontextprotocol/sdk";
+import { MCPClient, MCPClientConfig, MCPError } from "./types";
+
+export class MCPClientImpl implements MCPClient {
+  private serverUrl: string;
+  private timeout: number;
+  private headers: Record<string, string>;
+
+  constructor(config: MCPClientConfig) {
+    this.serverUrl = config.serverUrl;
+    this.timeout = config.timeout || 30000;
+    this.headers = {
+      "Content-Type": "application/json",
+      ...config.headers,
+    };
+  }
+
+  async getContext(request: ContextRequest): Promise<ContextResponse> {
+    try {
+      const response = await fetch(`${this.serverUrl}/context`, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(request),
+        signal: AbortSignal.timeout(this.timeout),
+      });
+
+      if (!response.ok) {
+        const error = new Error(
+          `HTTP error! status: ${response.status}`
+        ) as MCPError;
+        error.code = "MCP_CLIENT_ERROR";
+        error.status = response.status;
+        throw error;
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error instanceof Error) {
+        const mcpError = error as MCPError;
+        mcpError.code = mcpError.code || "MCP_CLIENT_ERROR";
+        throw mcpError;
+      }
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    // Cleanup any resources if needed
+  }
+}

--- a/packages/context-mcp/src/index.ts
+++ b/packages/context-mcp/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./types";
-export * from "./client";
-export * from "./server";
+export { MCPClientImpl as MCPClient } from "./client";
+export { MCPServerImpl as MCPServer } from "./server";

--- a/packages/context-mcp/src/server.ts
+++ b/packages/context-mcp/src/server.ts
@@ -1,0 +1,69 @@
+import {
+  Context,
+  ContextRequest,
+  ContextResponse,
+} from "@modelcontextprotocol/sdk";
+import {
+  ContextHandler,
+  MCPServer,
+  MCPServerConfig,
+  RequestHandler,
+} from "./types";
+
+export class MCPServerImpl implements MCPServer {
+  private port: number;
+  private host: string;
+  private cors: boolean;
+  private contextHandler?: ContextHandler;
+  private requestHandler?: RequestHandler;
+  private server?: any; // Using 'any' for simplicity, but should be properly typed based on your HTTP server
+
+  constructor(config: MCPServerConfig = {}) {
+    this.port = config.port || 3000;
+    this.host = config.host || "localhost";
+    this.cors = config.cors || false;
+  }
+
+  async start(): Promise<void> {
+    // This is a placeholder implementation
+    // In a real implementation, you would:
+    // 1. Create an HTTP server
+    // 2. Set up routes
+    // 3. Handle CORS if enabled
+    // 4. Start listening on the specified port
+    console.log(`MCP Server starting on ${this.host}:${this.port}`);
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      // Close the server and cleanup resources
+      console.log("MCP Server stopping");
+    }
+  }
+
+  onContext(handler: ContextHandler): void {
+    this.contextHandler = handler;
+  }
+
+  onRequest(handler: RequestHandler): void {
+    this.requestHandler = handler;
+  }
+
+  private async handleContextRequest(
+    context: Context
+  ): Promise<ContextResponse> {
+    if (!this.contextHandler) {
+      throw new Error("No context handler registered");
+    }
+    return this.contextHandler(context);
+  }
+
+  private async handleRequest(
+    request: ContextRequest
+  ): Promise<ContextResponse> {
+    if (!this.requestHandler) {
+      throw new Error("No request handler registered");
+    }
+    return this.requestHandler(request);
+  }
+}

--- a/packages/context-mcp/src/types.ts
+++ b/packages/context-mcp/src/types.ts
@@ -1,0 +1,33 @@
+import { Context, ContextRequest, ContextResponse } from '@modelcontextprotocol/sdk';
+
+export interface MCPClientConfig {
+  serverUrl: string;
+  timeout?: number;
+  headers?: Record<string, string>;
+}
+
+export interface MCPServerConfig {
+  port?: number;
+  host?: string;
+  cors?: boolean;
+}
+
+export interface MCPError extends Error {
+  code: string;
+  status?: number;
+}
+
+export type ContextHandler = (context: Context) => Promise<ContextResponse>;
+export type RequestHandler = (request: ContextRequest) => Promise<ContextResponse>;
+
+export interface MCPClient {
+  getContext(request: ContextRequest): Promise<ContextResponse>;
+  close(): Promise<void>;
+}
+
+export interface MCPServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  onContext(handler: ContextHandler): void;
+  onRequest(handler: RequestHandler): void;
+} 


### PR DESCRIPTION
- Added MCPClientImpl to manage context requests with configurable server URL, timeout, and headers, including error handling for HTTP responses and request failures.  
- Implemented MCPServerImpl as a basic server scaffold supporting context and request handlers, with configurable host, port, and CORS options.  
- Defined types and interfaces for client/server configurations, handlers, and custom errors to standardize usage.  
- Exported client and server implementations under unified names for easier consumption.