### PR TITLE
fix(web): update eventStream type for response body

### DIFF
--- a/packages/web/src/app/ai-tools/requirement-cockpit/page.tsx
+++ b/packages/web/src/app/ai-tools/requirement-cockpit/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
 
 			let aiResponse = ''
 
-			const eventStream: EventSourceParserStream = response.body!
+			const eventStream: ReadableStream<{ conversationId: string; data: string }> = response.body!
 				.pipeThrough(new TextDecoderStream())
 				.pipeThrough(new EventSourceParserStream())
             


### PR DESCRIPTION
Change eventStream type from EventSourceParserStream to a more
accurate ReadableStream with typed conversationId and data fields.
This improves type safety and aligns with the actual response body
structure for better maintainability.