### PR TITLE
feat(context-mcp): add modular capabilities system with prompts, tools, and resources

### DIFF
--- a/packages/context-mcp/src/capabilities.ts
+++ b/packages/context-mcp/src/capabilities.ts
@@ -1,0 +1,14 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { prompts } from "./capabilities/prompts.js";
+import { tools } from "./capabilities/tools.js";
+import { resources } from "./capabilities/resources.js";
+
+import type { ResourceMetadata } from "./capabilities/resources/_typing.js";
+
+// TODO: This metadata is really annoying, we should find a better way to do this.
+export function installCapabilities(mcpInst: McpServer, metadata: ResourceMetadata) {
+    resources.forEach(resource => resource(mcpInst.resource, metadata));
+    tools.forEach(tool => tool(mcpInst.tool));
+    prompts.forEach(prompt => prompt(mcpInst.prompt));
+}

--- a/packages/context-mcp/src/capabilities/prompts.ts
+++ b/packages/context-mcp/src/capabilities/prompts.ts
@@ -1,0 +1,6 @@
+import { PromptLike } from "./prompts/_typing.js";
+import { installReviewCodePrompt } from "./prompts/review_code.js";
+
+export const prompts: PromptLike[] = [
+    installReviewCodePrompt,
+];

--- a/packages/context-mcp/src/capabilities/prompts/README.md
+++ b/packages/context-mcp/src/capabilities/prompts/README.md
@@ -1,0 +1,7 @@
+# MCP Prompts
+
+This is a collection of prompts that can be used to extend the capabilities of the MCP server.
+
+## Review Code
+
+Returns the prompt for reviewing code.

--- a/packages/context-mcp/src/capabilities/prompts/_typing.ts
+++ b/packages/context-mcp/src/capabilities/prompts/_typing.ts
@@ -1,0 +1,3 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type PromptLike = (installer: McpServer["prompt"]) => void;

--- a/packages/context-mcp/src/capabilities/prompts/review_code.ts
+++ b/packages/context-mcp/src/capabilities/prompts/review_code.ts
@@ -1,0 +1,17 @@
+import { PromptLike } from "./_typing.js";
+
+import { z } from "zod";
+
+export const installReviewCodePrompt: PromptLike = (installer) => {
+  installer("review-code", { code: z.string() }, ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }));
+};

--- a/packages/context-mcp/src/capabilities/resources.ts
+++ b/packages/context-mcp/src/capabilities/resources.ts
@@ -1,0 +1,6 @@
+import { ResourceLike } from "./resources/_typing.js";
+import { installVersionResource } from "./resources/version";
+
+export const resources: ResourceLike[] = [
+    installVersionResource,
+];

--- a/packages/context-mcp/src/capabilities/resources/README.md
+++ b/packages/context-mcp/src/capabilities/resources/README.md
@@ -1,0 +1,7 @@
+# MCP Resources
+
+This is a collection of resources that can be used to extend the capabilities of the MCP server.
+
+## Version
+
+Returns the version of the MCP server.

--- a/packages/context-mcp/src/capabilities/resources/_typing.ts
+++ b/packages/context-mcp/src/capabilities/resources/_typing.ts
@@ -1,0 +1,9 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type ResourceMetadata = {
+    [x: string]: unknown;
+    name: string;
+    version: string;
+};
+
+export type ResourceLike = (installer: McpServer["resource"], metadata: ResourceMetadata) => void;

--- a/packages/context-mcp/src/capabilities/resources/version.ts
+++ b/packages/context-mcp/src/capabilities/resources/version.ts
@@ -1,0 +1,7 @@
+import { ResourceLike } from "./_typing.js";
+
+export const installVersionResource: ResourceLike = (installer) => {
+    installer("version", "mcp://version", { list: undefined }, (uri) => {
+        return { contents: [{ uri: uri.href, text: "1.0.0" }] };
+    });
+};

--- a/packages/context-mcp/src/capabilities/tools.ts
+++ b/packages/context-mcp/src/capabilities/tools.ts
@@ -1,0 +1,6 @@
+import { ToolLike } from "./tools/_typing.js";
+import { installAddTool } from "./tools/add.js";
+
+export const tools: ToolLike[] = [
+    installAddTool,
+];

--- a/packages/context-mcp/src/capabilities/tools/REAME.md
+++ b/packages/context-mcp/src/capabilities/tools/REAME.md
@@ -1,0 +1,8 @@
+# MCP Tools
+
+This is a collection of tools that can be used to extend the capabilities of the MCP server.
+
+## Add
+
+Adds two numbers together.
+

--- a/packages/context-mcp/src/capabilities/tools/_typing.ts
+++ b/packages/context-mcp/src/capabilities/tools/_typing.ts
@@ -1,0 +1,3 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type ToolLike = (installer: McpServer["tool"]) => void;

--- a/packages/context-mcp/src/capabilities/tools/add.ts
+++ b/packages/context-mcp/src/capabilities/tools/add.ts
@@ -1,0 +1,9 @@
+import { ToolLike } from "./_typing.js";
+
+import { z } from "zod";
+
+export const installAddTool: ToolLike = (installer) => {
+    installer("add", { a: z.number(), b: z.number() }, async ({ a, b }) => ({
+        content: [{ type: "text", text: String(a + b) }],
+    }));
+};

--- a/packages/context-mcp/src/index.ts
+++ b/packages/context-mcp/src/index.ts
@@ -1,2 +1,0 @@
-export { MCPServerImpl as MCPServer } from "./server";
-export type * from "./server";


### PR DESCRIPTION
- Introduce a modular capabilities system for the MCP server with prompts, tools, and resources  
- Add example capabilities such as review-code prompt, add tool, and version resource  
- Implement installCapabilities function to register capabilities on the MCP server instance  
- Refactor MCP server to integrate the new capabilities framework  
- Improve MCP HTTP transport session cleanup  
- Remove unused imports and export types for a cleaner codebase  
- Enable easier extension and better organization of MCP server features