### PR TITLE
feat(context-mcp): add GitHub PR comment tool for comment management

### DIFF
--- a/packages/context-mcp/package.json
+++ b/packages/context-mcp/package.json
@@ -37,11 +37,12 @@
     "@ast-grep/napi": "^0.38.1",
     "@modelcontextprotocol/sdk": "^1.11.1",
     "@octokit/rest": "^20.1.2",
-    "express": "^5.1.0",
     "@vscode/ripgrep": "^1.15.11",
+    "express": "^5.1.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@octokit/types": "^14.0.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/context-mcp/src/capabilities/tools/github-pr-comment.ts
+++ b/packages/context-mcp/src/capabilities/tools/github-pr-comment.ts
@@ -1,0 +1,182 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Octokit } from "@octokit/rest";
+import type { RestEndpointMethodTypes } from "@octokit/rest";
+
+type CommentResponse = RestEndpointMethodTypes["issues"]["createComment"]["response"]["data"];
+type ReactionResponse = RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]["data"];
+
+export const installGithubPrCommentTool: ToolLike = (installer) => {
+    installer(
+        "github-pr-comment",
+        "GitHub PR comment operations",
+        {
+            action: z.enum(["create", "list", "edit", "delete", "add_reaction"]).describe("Action to perform"),
+            owner: z.string().describe("Repository owner"),
+            repo: z.string().describe("Repository name"),
+            pull_number: z.number().describe("PR number"),
+            body: z.string().optional().describe("Comment content"),
+            comment_id: z.number().optional().describe("Comment ID to operate on"),
+            commit_id: z.string().optional().describe("Commit ID to comment on"),
+            path: z.string().optional().describe("File path to comment on"),
+            position: z.number().optional().describe("Line position in the file"),
+            line: z.number().optional().describe("Line number in the file"),
+            reaction: z.enum(["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"]).optional().describe("Reaction to add"),
+        },
+        async (args) => {
+            const { action, owner, repo, pull_number, body, comment_id, commit_id, path, position, line, reaction } = args;
+            const octokit = new Octokit({
+                auth: process.env.GITHUB_TOKEN,
+            });
+
+            let response: any;
+
+            switch (action) {
+                case "list":
+                    // List all comments on a PR
+                    const listResponse = await octokit.issues.listComments({
+                        owner,
+                        repo,
+                        issue_number: pull_number,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify(
+                                    listResponse.data.map(comment => ({
+                                        id: comment.id,
+                                        body: comment.body,
+                                        user: comment.user?.login,
+                                        created_at: comment.created_at,
+                                        updated_at: comment.updated_at,
+                                        html_url: comment.html_url,
+                                    })),
+                                    null,
+                                    2
+                                ),
+                            },
+                        ],
+                    };
+
+                case "edit":
+                    if (!comment_id || !body) {
+                        throw new Error("Comment ID and body are required for editing");
+                    }
+                    response = await octokit.issues.updateComment({
+                        owner,
+                        repo,
+                        comment_id,
+                        body,
+                    });
+                    break;
+
+                case "delete":
+                    if (!comment_id) {
+                        throw new Error("Comment ID is required for deletion");
+                    }
+                    await octokit.issues.deleteComment({
+                        owner,
+                        repo,
+                        comment_id,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({ message: "Comment deleted successfully" }),
+                            },
+                        ],
+                    };
+
+                case "add_reaction":
+                    if (!comment_id || !reaction) {
+                        throw new Error("Comment ID and reaction are required for adding reactions");
+                    }
+                    response = await octokit.reactions.createForIssueComment({
+                        owner,
+                        repo,
+                        comment_id,
+                        content: reaction,
+                    });
+                    break;
+
+                case "create":
+                default:
+                    // Reply to an existing comment
+                    if (comment_id) {
+                        response = await octokit.issues.createComment({
+                            owner,
+                            repo,
+                            issue_number: pull_number,
+                            body: body!,
+                            in_reply_to: comment_id,
+                        });
+                    }
+                    // Comment on a specific commit
+                    else if (commit_id) {
+                        response = await octokit.repos.createCommitComment({
+                            owner,
+                            repo,
+                            commit_sha: commit_id,
+                            body: body!,
+                        });
+                    }
+                    // Comment on a specific file and line
+                    else if (path && (position !== undefined || line !== undefined)) {
+                        response = await octokit.pulls.createReview({
+                            owner,
+                            repo,
+                            pull_number,
+                            body: body!,
+                            commit_id: commit_id,
+                            path,
+                            position,
+                            line,
+                        });
+                    }
+                    // Regular PR comment
+                    else {
+                        response = await octokit.issues.createComment({
+                            owner,
+                            repo,
+                            issue_number: pull_number,
+                            body: body!,
+                        });
+                    }
+            }
+
+            if (response) {
+                const responseData = response.data as CommentResponse | ReactionResponse;
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify(
+                                {
+                                    id: responseData.id,
+                                    body: 'body' in responseData ? responseData.body : undefined,
+                                    user: responseData.user?.login,
+                                    created_at: 'created_at' in responseData ? responseData.created_at : undefined,
+                                    updated_at: 'updated_at' in responseData ? responseData.updated_at : undefined,
+                                    html_url: 'html_url' in responseData ? responseData.html_url : undefined,
+                                },
+                                null,
+                                2
+                            ),
+                        },
+                    ],
+                };
+            }
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({ message: "Operation completed successfully" }),
+                    },
+                ],
+            };
+        }
+    );
+}; 

--- a/packages/context-mcp/src/capabilities/tools/github-pr-update.ts
+++ b/packages/context-mcp/src/capabilities/tools/github-pr-update.ts
@@ -1,0 +1,80 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Octokit } from "@octokit/rest";
+
+export const installGithubPrUpdateTool: ToolLike = (installer) => {
+    installer(
+        "github-pr-update",
+        {
+            owner: z.string().describe("Repository owner"),
+            repo: z.string().describe("Repository name"),
+            pull_number: z.number().describe("PR number"),
+            title: z.string().optional().describe("New PR title"),
+            body: z.string().optional().describe("New PR description"),
+            assignees: z.array(z.string()).optional().describe("List of usernames to assign to the PR"),
+            reviewers: z.array(z.string()).optional().describe("List of usernames to request review from"),
+            state: z.enum(["open", "closed"]).optional().describe("PR state"),
+            base: z.string().optional().describe("The branch you want the changes pulled into"),
+        },
+        async ({ owner, repo, pull_number, title, body, assignees, reviewers, state, base }) => {
+            const octokit = new Octokit({
+                auth: process.env.GITHUB_TOKEN,
+            });
+
+            // Update PR details
+            const updateParams: any = {
+                owner,
+                repo,
+                pull_number,
+            };
+
+            if (title) updateParams.title = title;
+            if (body) updateParams.body = body;
+            if (state) updateParams.state = state;
+            if (base) updateParams.base = base;
+
+            const { data: pr } = await octokit.pulls.update(updateParams);
+
+            // Update assignees if provided
+            if (assignees) {
+                await octokit.issues.addAssignees({
+                    owner,
+                    repo,
+                    issue_number: pull_number,
+                    assignees,
+                });
+            }
+
+            // Update reviewers if provided
+            if (reviewers) {
+                await octokit.pulls.requestReviewers({
+                    owner,
+                    repo,
+                    pull_number,
+                    reviewers,
+                });
+            }
+
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify(
+                            {
+                                number: pr.number,
+                                title: pr.title,
+                                state: pr.state,
+                                html_url: pr.html_url,
+                                updated_at: pr.updated_at,
+                                assignees: pr.assignees?.map(a => a.login),
+                                requested_reviewers: pr.requested_reviewers?.map(r => r.login),
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}; 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.11.1
         version: 1.11.1
-        
       '@octokit/rest':
         specifier: ^20.1.2
         version: 20.1.2
@@ -95,6 +94,9 @@ importers:
         specifier: ^3.24.4
         version: 3.24.4
     devDependencies:
+      '@octokit/types':
+        specifier: ^14.0.0
+        version: 14.0.0
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.8(rollup@4.40.2)
@@ -3051,6 +3053,9 @@ packages:
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
+  '@octokit/openapi-types@25.0.0':
+    resolution: {integrity: sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==}
+
   '@octokit/plugin-paginate-rest@11.4.4-cjs.2':
     resolution: {integrity: sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==}
     engines: {node: '>= 18'}
@@ -3083,6 +3088,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.0.0':
+    resolution: {integrity: sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -14497,6 +14505,8 @@ snapshots:
 
   '@octokit/openapi-types@24.2.0': {}
 
+  '@octokit/openapi-types@25.0.0': {}
+
   '@octokit/plugin-paginate-rest@11.4.4-cjs.2(@octokit/core@5.2.1)':
     dependencies:
       '@octokit/core': 5.2.1
@@ -14534,6 +14544,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.0.0':
+    dependencies:
+      '@octokit/openapi-types': 25.0.0
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
- Added a new tool for managing GitHub pull request comments.
- Implemented features to create, list, edit, and delete PR comments.
- Added support for adding reactions to PR comments.
- Utilized the Octokit REST API for automated and programmatic comment management.
- Enhanced integration and workflow automation for PR reviews and discussions.