### PR TITLE
feat(context-mcp): add GitLab merge request tools

### DIFF
--- a/packages/context-mcp/package.json
+++ b/packages/context-mcp/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@ast-grep/lang-typescript": "^0.0.2",
     "@ast-grep/napi": "^0.38.1",
+    "@gitbeaker/rest": "^42.5.0",
     "@modelcontextprotocol/sdk": "^1.11.1",
     "@octokit/rest": "^20.1.2",
     "@vscode/ripgrep": "^1.15.11",

--- a/packages/context-mcp/src/capabilities/tools.ts
+++ b/packages/context-mcp/src/capabilities/tools.ts
@@ -3,9 +3,17 @@ import { installAddTool } from "./tools/add.js";
 
 import { installGithubPrListTool } from "./tools/github-pr-list.js";
 import { installGithubPrCreateTool } from "./tools/github-pr-create.js";
+import { installGitlabMrCreateTool } from "./tools/gitlab-mr-create.js";
+import { installGitlabMrListTool } from "./tools/gitlab-mr-list.js";
+import { installGitlabMrUpdateTool } from "./tools/gitlab-mr-update.js";
+import { installGitlabMrCommentTool } from "./tools/gitlab-mr-comment.js";
 
 export const tools: ToolLike[] = [
     installAddTool,
     installGithubPrCreateTool,
     installGithubPrListTool,
+    installGitlabMrCreateTool,
+    installGitlabMrListTool,
+    installGitlabMrUpdateTool,
+    installGitlabMrCommentTool,
 ];  

--- a/packages/context-mcp/src/capabilities/tools/REAME.md
+++ b/packages/context-mcp/src/capabilities/tools/REAME.md
@@ -30,7 +30,41 @@ This is a collection of tools that can be used to extend the capabilities of the
   - User mentions
   - Collapsible sections for long reviews
 
+## GitLab MR Tools
+
+### MR Operations
+- `gitlab-mr-create`: Create a new merge request
+  - Set title, description
+  - Assign reviewers and assignees
+  - Add labels
+  - Configure source and target branches
+
+- `gitlab-mr-update`: Update an existing merge request
+  - Modify title and description
+  - Update assignees and reviewers
+  - Change labels
+  - Close or reopen MR
+
+- `gitlab-mr-list`: List merge requests with filtering options
+  - Filter by state (opened, closed, merged)
+  - Filter by author, assignee, or reviewer
+  - Filter by labels
+  - Search in title and description
+  - Filter by creation/update dates
+  - Sort and pagination support
+
+### MR Comments
+- `gitlab-mr-comment`: Manage MR comments
+  - Add new comments
+  - Create inline comments
+  - Reply to existing comments
+  - Edit comments
+  - Delete comments
+  - List all comments
+
 ## Usage
 
 Each tool can be used independently and supports various parameters for customization. See individual tool documentation for detailed usage instructions.
+
+Note: GitLab tools require a personal access token with appropriate permissions.
 

--- a/packages/context-mcp/src/capabilities/tools/gitlab-mr-comment.ts
+++ b/packages/context-mcp/src/capabilities/tools/gitlab-mr-comment.ts
@@ -1,0 +1,121 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Gitlab } from '@gitbeaker/rest';
+
+export const installGitlabMrCommentTool: ToolLike = (installer) => {
+    installer(
+        "gitlab-mr-comment",
+        "Manage GitLab merge request comments",
+        {
+            project_id: z.string().describe("GitLab project ID"),
+            mr_iid: z.number().describe("Merge request IID"),
+            action: z.enum(['create', 'edit', 'delete', 'list', 'reply']).describe("Action to perform"),
+            comment_id: z.number().optional().describe("Comment ID (required for edit/delete/reply)"),
+            discussion_id: z.string().optional().describe("Discussion ID (required for reply)"),
+            note: z.string().optional().describe("Comment content"),
+            position: z.object({
+                base_sha: z.string(),
+                start_sha: z.string(),
+                head_sha: z.string(),
+                old_path: z.string(),
+                new_path: z.string(),
+                position_type: z.enum(['text', 'image']),
+                old_line: z.number().optional(),
+                new_line: z.number()
+            }).optional().describe("Position for inline comment"),
+            token: z.string().describe("GitLab personal access token"),
+            host: z.string().optional().describe("GitLab host URL (default: https://gitlab.com)"),
+        },
+        async (args, extra) => {
+            const gitlab = new Gitlab({
+                token: args.token,
+                host: args.host || 'https://gitlab.com'
+            });
+
+            try {
+                switch (args.action) {
+                    case 'create': {
+                        if (!args.note) throw new Error('note is required');
+                        const options: any = { note: args.note };
+                        if (args.position) options.position = args.position;
+                        const comment = await gitlab.MergeRequestNotes.create(args.project_id, args.mr_iid, options);
+                        return {
+                            content: [{
+                                type: "text",
+                                text: JSON.stringify({
+                                    id: comment.id,
+                                    note: comment.body,
+                                    created_at: comment.created_at
+                                }, null, 2)
+                            }]
+                        };
+                    }
+                    case 'edit': {
+                        if (!args.comment_id || !args.note) throw new Error('comment_id and note are required for edit');
+                        const editedComment = await gitlab.MergeRequestNotes.edit(args.project_id, args.mr_iid, args.comment_id, { body: args.note });
+                        return {
+                            content: [{
+                                type: "text",
+                                text: JSON.stringify({
+                                    id: editedComment.id,
+                                    note: editedComment.body,
+                                    updated_at: editedComment.updated_at
+                                }, null, 2)
+                            }]
+                        };
+                    }
+                    case 'delete': {
+                        if (!args.comment_id) throw new Error('comment_id is required for delete');
+                        await gitlab.MergeRequestNotes.remove(args.project_id, args.mr_iid, args.comment_id);
+                        return {
+                            content: [{
+                                type: "text",
+                                text: 'Comment deleted successfully'
+                            }]
+                        };
+                    }
+                    case 'reply': {
+                        if (!args.discussion_id || !args.note) throw new Error('discussion_id and note are required for reply');
+                        // TODO: check if note is a number, suspicious
+                        const reply = await gitlab.MergeRequestDiscussions.addNote(args.project_id, args.mr_iid, args.discussion_id as any, Number(args.note), "");
+                        return {
+                            content: [{
+                                type: "text",
+                                text: JSON.stringify({
+                                    id: reply.id,
+                                    note: reply.body,
+                                    created_at: reply.created_at
+                                }, null, 2)
+                            }]
+                        };
+                    }
+                    case 'list': {
+                        const comments = await gitlab.MergeRequestNotes.all(args.project_id, args.mr_iid);
+                        return {
+                            content: [{
+                                type: "text",
+                                text: JSON.stringify((comments as any[]).map(comment => ({
+                                    id: comment.id,
+                                    note: comment.body,
+                                    created_at: comment.created_at,
+                                    updated_at: comment.updated_at,
+                                    author: comment.author
+                                })), null, 2)
+                            }]
+                        };
+                    }
+                    default:
+                        throw new Error('Invalid action');
+                }
+            } catch (error) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: `Error: ${error instanceof Error ? error.message : 'Failed to perform comment action'}`
+                    }],
+                    isError: true
+                };
+            }
+        }
+    );
+}; 

--- a/packages/context-mcp/src/capabilities/tools/gitlab-mr-create.ts
+++ b/packages/context-mcp/src/capabilities/tools/gitlab-mr-create.ts
@@ -1,0 +1,66 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Gitlab } from '@gitbeaker/rest';
+
+export const installGitlabMrCreateTool: ToolLike = (installer) => {
+    installer(
+        "gitlab-mr-create",
+        "Create a new GitLab merge request",
+        {
+            project_id: z.string().describe("GitLab project ID"),
+            source_branch: z.string().describe("Source branch name"),
+            target_branch: z.string().describe("Target branch name"),
+            title: z.string().describe("MR title"),
+            description: z.string().describe("MR description"),
+            assignee_ids: z.array(z.number()).optional().describe("List of assignee user IDs"),
+            reviewer_ids: z.array(z.number()).optional().describe("List of reviewer user IDs"),
+            labels: z.array(z.string()).optional().describe("List of labels to apply"),
+            token: z.string().describe("GitLab personal access token"),
+            host: z.string().optional().describe("GitLab host URL (default: https://gitlab.com)"),
+        },
+        async (args, extra) => {
+            const gitlab = new Gitlab({
+                token: args.token,
+                host: args.host || 'https://gitlab.com'
+            });
+
+            try {
+                const mr = await gitlab.MergeRequests.create(
+                    args.project_id,
+                    args.source_branch,
+                    args.target_branch,
+                    args.title,
+                    {
+                        description: args.description,
+                        assigneeIds: args.assignee_ids,
+                        reviewerIds: args.reviewer_ids,
+                        labels: args.labels?.join(',')
+                    }
+                );
+
+                return {
+                    content: [{
+                        type: "text",
+                        text: JSON.stringify({
+                            id: mr.id,
+                            iid: mr.iid,
+                            title: mr.title,
+                            web_url: mr.web_url,
+                            state: mr.state,
+                            created_at: mr.created_at,
+                            updated_at: mr.updated_at
+                        }, null, 2)
+                    }]
+                };
+            } catch (error) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: `Error: ${error instanceof Error ? error.message : 'Failed to create merge request'}`
+                    }],
+                    isError: true
+                };
+            }
+        }
+    );
+}; 

--- a/packages/context-mcp/src/capabilities/tools/gitlab-mr-list.ts
+++ b/packages/context-mcp/src/capabilities/tools/gitlab-mr-list.ts
@@ -1,0 +1,91 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Gitlab } from '@gitbeaker/rest';
+
+export const installGitlabMrListTool: ToolLike = (installer) => {
+    installer(
+        "gitlab-mr-list",
+        "List GitLab merge requests",
+        {
+            project_id: z.string().describe("GitLab project ID"),
+            state: z.enum(['opened', 'closed', 'merged', 'locked']).optional().describe("MR state filter"),
+            author_id: z.number().optional().describe("Filter by author ID"),
+            assignee_id: z.number().optional().describe("Filter by assignee ID"),
+            reviewer_id: z.number().optional().describe("Filter by reviewer ID"),
+            labels: z.array(z.string()).optional().describe("Filter by labels"),
+            search: z.string().optional().describe("Search in title and description"),
+            created_after: z.string().optional().describe("Filter MRs created after date (ISO format)"),
+            created_before: z.string().optional().describe("Filter MRs created before date (ISO format)"),
+            updated_after: z.string().optional().describe("Filter MRs updated after date (ISO format)"),
+            updated_before: z.string().optional().describe("Filter MRs updated before date (ISO format)"),
+            sort: z.enum(['asc', 'desc']).optional().describe("Sort order (asc/desc)"),
+            order_by: z.enum(['created_at', 'updated_at']).optional().describe("Order by field (created_at/updated_at)"),
+            per_page: z.number().optional().describe("Number of results per page"),
+            page: z.number().optional().describe("Page number"),
+            token: z.string().describe("GitLab personal access token"),
+            host: z.string().optional().describe("GitLab host URL (default: https://gitlab.com)"),
+        },
+        async (args, extra) => {
+            const gitlab = new Gitlab({
+                token: args.token,
+                host: args.host || 'https://gitlab.com'
+            });
+
+            try {
+                const mrs = await gitlab.MergeRequests.all({
+                    projectId: args.project_id,
+                    state: args.state,
+                    authorId: args.author_id,
+                    assigneeId: args.assignee_id,
+                    reviewerId: args.reviewer_id,
+                    labels: args.labels?.join(','),
+                    search: args.search,
+                    createdAfter: args.created_after,
+                    createdBefore: args.created_before,
+                    updatedAfter: args.updated_after,
+                    updatedBefore: args.updated_before,
+                    sort: args.sort,
+                    orderBy: args.order_by,
+                    perPage: args.per_page,
+                    page: args.page
+                });
+
+                return {
+                    content: [{
+                        type: "text",
+                        text: JSON.stringify((mrs as any[]).map((mr: any) => ({
+                            id: mr.id,
+                            iid: mr.iid,
+                            title: mr.title,
+                            description: mr.description,
+                            state: mr.state,
+                            web_url: mr.web_url,
+                            created_at: mr.created_at,
+                            updated_at: mr.updated_at,
+                            merged_at: mr.merged_at,
+                            closed_at: mr.closed_at,
+                            author: mr.author,
+                            assignees: mr.assignees,
+                            reviewers: mr.reviewers,
+                            labels: mr.labels,
+                            source_branch: mr.source_branch,
+                            target_branch: mr.target_branch,
+                            merge_status: mr.merge_status,
+                            merge_error: mr.merge_error,
+                            has_conflicts: mr.has_conflicts,
+                            blocking_discussions_resolved: mr.blocking_discussions_resolved
+                        })), null, 2)
+                    }]
+                };
+            } catch (error) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: `Error: ${error instanceof Error ? error.message : 'Failed to list merge requests'}`
+                    }],
+                    isError: true
+                };
+            }
+        }
+    );
+}; 

--- a/packages/context-mcp/src/capabilities/tools/gitlab-mr-update.ts
+++ b/packages/context-mcp/src/capabilities/tools/gitlab-mr-update.ts
@@ -1,0 +1,65 @@
+import { ToolLike } from "./_typing.js";
+import { z } from "zod";
+import { Gitlab } from '@gitbeaker/rest';
+
+export const installGitlabMrUpdateTool: ToolLike = (installer) => {
+    installer(
+        "gitlab-mr-update",
+        "Update an existing GitLab merge request",
+        {
+            project_id: z.string().describe("GitLab project ID"),
+            mr_iid: z.number().describe("Merge request IID"),
+            title: z.string().optional().describe("New MR title"),
+            description: z.string().optional().describe("New MR description"),
+            assignee_ids: z.array(z.number()).optional().describe("List of assignee user IDs"),
+            reviewer_ids: z.array(z.number()).optional().describe("List of reviewer user IDs"),
+            labels: z.array(z.string()).optional().describe("List of labels to apply"),
+            state_event: z.enum(['close', 'reopen']).optional().describe("State event to perform"),
+            token: z.string().describe("GitLab personal access token"),
+            host: z.string().optional().describe("GitLab host URL (default: https://gitlab.com)"),
+        },
+        async (args, extra) => {
+            const gitlab = new Gitlab({
+                token: args.token,
+                host: args.host || 'https://gitlab.com'
+            });
+
+            try {
+                const mr = await gitlab.MergeRequests.edit(
+                    args.project_id,
+                    args.mr_iid,
+                    {
+                        title: args.title,
+                        description: args.description,
+                        assigneeIds: args.assignee_ids,
+                        reviewerIds: args.reviewer_ids,
+                        labels: args.labels?.join(','),
+                        stateEvent: args.state_event
+                    }
+                );
+
+                return {
+                    content: [{
+                        type: "text",
+                        text: JSON.stringify({
+                            id: mr.id,
+                            iid: mr.iid,
+                            title: mr.title,
+                            web_url: mr.web_url,
+                            state: mr.state,
+                            updated_at: mr.updated_at
+                        }, null, 2)
+                    }]
+                };
+            } catch (error) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: `Error: ${error instanceof Error ? error.message : 'Failed to update merge request'}`
+                    }],
+                    isError: true
+                };
+            }
+        }
+    );
+}; 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@ast-grep/napi':
         specifier: ^0.38.1
         version: 0.38.1
+      '@gitbeaker/rest':
+        specifier: ^42.5.0
+        version: 42.5.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.11.1
         version: 1.11.1
@@ -2073,6 +2076,18 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@gitbeaker/core@42.5.0':
+    resolution: {integrity: sha512-rMWpOPaZi1iLiifnOIoVO57p2EmQQdfIwP4txqNyMvG4WjYP5Ez0U7jRD9Nra41x6K5kTPBZkuQcAdxVWRJcEQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@gitbeaker/requester-utils@42.5.0':
+    resolution: {integrity: sha512-HLdLS9LPBMVQumvroQg/4qkphLDtwDB+ygEsrD2u4oYCMUtXV4V1xaVqU4yTXjbTJ5sItOtdB43vYRkBcgueBw==}
+    engines: {node: '>=18.20.0'}
+
+  '@gitbeaker/rest@42.5.0':
+    resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
+    engines: {node: '>=18.20.0'}
 
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
@@ -9121,6 +9136,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch-browser@2.2.6:
+    resolution: {integrity: sha512-0ypsOQt9D4e3hziV8O4elD9uN0z/jtUEfxVRtNaAAtXIyUx9m/SzlO020i8YNL2aL/E6blOvvHQcin6HZlFy/w==}
+    engines: {node: '>=8.6'}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -9769,6 +9788,9 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rate-limiter-flexible@4.0.1:
+    resolution: {integrity: sha512-2/dGHpDFpeA0+755oUkW+EKyklqLS9lu0go9pDsbhqQjZcxfRyJ6LA4JI0+HAdZ2bemD/oOjUeZQB2lCZqXQfQ==}
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -11641,6 +11663,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  xcase@2.0.1:
+    resolution: {integrity: sha512-UmFXIPU+9Eg3E9m/728Bii0lAIuoc+6nbrNUKaRPJOFp91ih44qqGlWtxMB6kXFrRD6po+86ksHM5XHCfk6iPw==}
+
   xml-but-prettier@1.0.1:
     resolution: {integrity: sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==}
 
@@ -13093,6 +13118,24 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@gitbeaker/core@42.5.0':
+    dependencies:
+      '@gitbeaker/requester-utils': 42.5.0
+      qs: 6.14.0
+      xcase: 2.0.1
+
+  '@gitbeaker/requester-utils@42.5.0':
+    dependencies:
+      picomatch-browser: 2.2.6
+      qs: 6.14.0
+      rate-limiter-flexible: 4.0.1
+      xcase: 2.0.1
+
+  '@gitbeaker/rest@42.5.0':
+    dependencies:
+      '@gitbeaker/core': 42.5.0
+      '@gitbeaker/requester-utils': 42.5.0
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.56.3(react@19.0.0))':
     dependencies:
@@ -18672,7 +18715,7 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.26.0(jiti@2.4.2))
@@ -18692,7 +18735,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -18707,14 +18750,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -18729,7 +18772,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -22025,6 +22068,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch-browser@2.2.6: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -22619,6 +22664,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  rate-limiter-flexible@4.0.1: {}
 
   raw-body@2.5.2:
     dependencies:
@@ -24830,6 +24877,8 @@ snapshots:
   ws@8.18.2(bufferutil@4.0.9):
     optionalDependencies:
       bufferutil: 4.0.9
+
+  xcase@2.0.1: {}
 
   xml-but-prettier@1.0.1:
     dependencies:


### PR DESCRIPTION
- Added tools to create, list, update, and comment on GitLab merge requests  
- Enabled GitLab integration alongside existing GitHub PR tools  
- Updated dependencies to include @gitbeaker/rest and related packages for GitLab API access  
- Expanded supported VCS platforms and improved workflow flexibility