### PR TITLE
feat(context-mcp): improve capability installation and server API

### DIFF
--- a/packages/context-mcp/example/README.md
+++ b/packages/context-mcp/example/README.md
@@ -1,0 +1,24 @@
+# Example MCP Server
+
+This is a simple example of an MCP (Message Control Protocol) server implementation. The server demonstrates how to:
+
+1. Create and configure an MCP server
+2. Start the server with HTTP support
+
+## Running the Example
+
+To run the example server:
+
+```bash
+# From the context-mcp directory
+pnpm run run-example
+```
+
+The server will start on port 3000.
+
+## Server Configuration
+
+The example server is configured with:
+- Server name: example-mcp-server
+- Version: 1.0.0
+- Port: 3000

--- a/packages/context-mcp/example/server.ts
+++ b/packages/context-mcp/example/server.ts
@@ -1,0 +1,18 @@
+import { MCPServer } from '..';
+
+// Create and configure the MCP server
+const server = new MCPServer({
+  name: 'example-mcp-server',
+  version: '1.0.0',
+});
+
+server.serveHttp({
+  port: 3000,
+}).then(server => {
+    console.log(`Server is running on http://localhost:3000`);
+    console.log(`You can connect to the server using the following command:`);
+    console.log(`mcp connect http://localhost:3000`);
+}).catch(err => {
+    console.error(err);
+});
+

--- a/packages/context-mcp/package.json
+++ b/packages/context-mcp/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
+    "run-example": "pnpm run build && npx tsx example/server.ts",
     "test": "nx jest:test",
     "lint": "eslint src --ext .ts,.tsx",
     "clean": "rimraf dist",

--- a/packages/context-mcp/src/capabilities.ts
+++ b/packages/context-mcp/src/capabilities.ts
@@ -8,7 +8,7 @@ import type { ResourceMetadata } from "./capabilities/resources/_typing.js";
 
 // TODO: This metadata is really annoying, we should find a better way to do this.
 export function installCapabilities(mcpInst: McpServer, metadata: ResourceMetadata) {
-    resources.forEach(resource => resource(mcpInst.resource, metadata));
-    tools.forEach(tool => tool(mcpInst.tool));
-    prompts.forEach(prompt => prompt(mcpInst.prompt));
+    resources.forEach(resource => resource(mcpInst.resource.bind(mcpInst), metadata));
+    tools.forEach(tool => tool(mcpInst.tool.bind(mcpInst)));
+    prompts.forEach(prompt => prompt(mcpInst.prompt.bind(mcpInst)));
 }

--- a/packages/context-mcp/src/server.ts
+++ b/packages/context-mcp/src/server.ts
@@ -60,32 +60,32 @@ export class MCPServerImpl {
     installCapabilities(this.mcpInst, impl);
   }
 
-  ensureExpressApp() /* asserts this.expressApp is Application */{
+  private ensureExpressApp() /* asserts this.expressApp is Application */{
     if (!this.expressApp) {
       this.expressApp = express();
       this.expressApp.use(express.json());
     }
   }
 
-  ensureMcpHttpTransportSessions() /* asserts this.mcpHttpTransportSessions is { [sessionId: string]: McpHttpTransport } */{
+  private ensureMcpHttpTransportSessions() /* asserts this.mcpHttpTransportSessions is { [sessionId: string]: McpHttpTransport } */{
     if (!this.mcpHttpTransportSessions) {
       this.mcpHttpTransportSessions = {};
     }
   }
 
-  ensureMcpStdioTransport() /* asserts this.mcpStdioTransport is McpStdioTransport */{
+  private ensureMcpStdioTransport() /* asserts this.mcpStdioTransport is McpStdioTransport */{
     if (!this.mcpStdioTransport) {
       this.mcpStdioTransport = new McpStdioTransport();
     }
   }
 
-  ensureDestroyed() /* asserts this.isDestroyed is false */{
+  private ensureDestroyed() /* asserts this.isDestroyed is false */{
     if (!this.isDestroyed) {
       throw new Error("MCPServer is still running");
     }
   }
 
-  async serveHttp(options: HttpServeOptions) {
+  async serveHttp(options: HttpServeOptions) : Promise<http.Server> {
     this.ensureDestroyed();
     this.ensureExpressApp();
     if (!this.expressApp) throw new Error("Failed to create Express app"); // Type guard
@@ -178,6 +178,8 @@ export class MCPServerImpl {
     } else {
       this.managedHttpServer = this.expressApp.listen(options.port);
     }
+
+    return this.managedHttpServer;
   }
 
   async serveStdio() {


### PR DESCRIPTION
- Bind MCP server instance methods during capability installation to preserve correct context and fix `this` reference issues in handlers.
- Make several internal methods in MCPServerImpl private to improve encapsulation and maintainability.
- Add explicit return type and return the HTTP server instance from `serveHttp` for better server management.
- Include an example MCP server with README and run script to demonstrate usage and provide a user starting point.