### PR TITLE
chore: allow publishing from main, master, or workspace branches

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ onlyBuiltDependencies:
   - sharp
   - sqlite3
   - vscode-ripgrep
+publishBranch: "main|master|gitbutler/workspace"


### PR DESCRIPTION
- Updated pnpm-workspace.yaml to include a publishBranch pattern matching "main", "master", and "gitbutler/workspace"
- Enabled publishing workflows to run on these branches
- Improved flexibility and support for multiple release branches