### PR TITLE
chore(ci): reorder release workflow steps for clarity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7.0.8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "chore: release ${{ inputs.version }} version"
-          body: "This PR contains version updates for ${{ inputs.version }} release"
-          base-branch: master
-          head-branch: release/$(date +%Y%m%d-%H%M%S)
-
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -63,11 +54,20 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Create Release PR
+      - name: Do release without publishing
         run: |
           pnpm nx release ${{ inputs.version }} --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore: release ${{ inputs.version }} version"
+          body: "This PR contains version updates for ${{ inputs.version }} release"
+          base-branch: master
+          head-branch: release/$(date +%Y%m%d-%H%M%S)
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
Move the pull request creation step to occur after the release
command with --skip-publish. This change ensures the release PR
includes all version updates generated by the release process,
improving workflow correctness and clarity.