### PR TITLE
fix(ci): correct base ref for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore: release ${{ inputs.version }} version"
           body: "This PR contains version updates for ${{ inputs.version }} release"
-          base: ${{ github.ref_name }}
+          base: ${{ github.ref }}
           branch: release/$(date +%Y%m%d-%H%M%S)
 
   publish:


### PR DESCRIPTION
Update the release workflow to use the full ref instead of just the
ref name for the base branch. This ensures the release PR targets the