### PR TITLE
fix(ci): correct base branch reference in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore: release ${{ inputs.version }} version"
           body: "This PR contains version updates for ${{ inputs.version }} release"
-          base: ${{ github.ref }}
+          base: ${{ github.base_ref }}
           branch: release/$(date +%Y%m%d-%H%M%S)
 
   publish:


### PR DESCRIPTION
Update the release GitHub Actions workflow to use the correct base
branch reference by replacing 'github.ref' with 'github.base_ref'.
This ensures the release pull request targets the intended base branch,
preventing potential merge conflicts and improving release accuracy.