### PR TITLE
ci: set current date env variable for release branch name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
         with:
@@ -67,7 +70,7 @@ jobs:
           title: "chore: release ${{ inputs.version }} version"
           body: "This PR contains version updates for ${{ inputs.version }} release"
           base: ${{ github.base_ref }}
-          branch: release/${{ steps.date.outputs.date }}
+          branch: release/${{ env.NOW }}
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
Add a step in the release workflow to set the current date as an
environment variable. Use this date variable to name the release
branch instead of relying on a previous step output. This change
simplifies the workflow and ensures the branch name always reflects
the current date at runtime.