### PR TITLE
feat(context-mcp): add stubs for project-related tools

### DIFF
--- a/packages/context-mcp/src/capabilities/tools/project/get-project-context.ts
+++ b/packages/context-mcp/src/capabilities/tools/project/get-project-context.ts
@@ -1,0 +1,15 @@
+import { ToolLike } from "../_typing.js";
+
+export const getProjectContext: ToolLike = (installer) => {
+  installer(
+    "get-project-context",
+    "Get the context of a project",
+    {},
+    async (params) => {
+      // TODO: Implement it
+      return {
+        content: [],
+      };
+    }
+  );
+};

--- a/packages/context-mcp/src/capabilities/tools/project/resolve-project.ts
+++ b/packages/context-mcp/src/capabilities/tools/project/resolve-project.ts
@@ -1,0 +1,25 @@
+import { ToolLike } from "../_typing.js";
+
+import { z } from "zod";
+
+export const resolveProject: ToolLike = (installer) => {
+  installer(
+    "resolve-project",
+    "Resolve a project from a given path",
+    {
+      path: z.string().describe("The path to the project"),
+    },
+    async (params) => {
+      const { path } = params;
+      // TODO: Implement it
+      return {
+        content: [
+          {
+            type: "text",
+            text: "",
+          },
+        ],
+      };
+    }
+  );
+};


### PR DESCRIPTION
Introduce initial implementations for resolve-project and get-project-context
tools with basic structure and parameter validation. These serve as placeholders
to enable further development of project resolution and context retrieval
functionality.