### PR TITLE
feat(context-mcp): add preset support and organize tools

### DIFF
--- a/packages/context-mcp/README.md
+++ b/packages/context-mcp/README.md
@@ -8,7 +8,7 @@ Model Context Protocol implementation for AutoDev.
   "mcpServers": {
     "autodev-context-mcp": {
       "command": "npx",
-      "args": ["--package=@autodev/context-mcp", "autodev-context-mcp"]
+      "args": ["--package=@autodev/context-mcp", "autodev-context-mcp", "--preset=AutoDev"]
     }
   }
 }

--- a/packages/context-mcp/bin/index.js
+++ b/packages/context-mcp/bin/index.js
@@ -4,6 +4,28 @@ const { MCPServer } = require("../dist/index.js");
 
 const PKG = require("../package.json");
 
+const { Presets } = require("../dist/_typing.js");
+
+// parse --preset flag
+const presetArg = process.argv.find((arg) => arg.startsWith("--preset="));
+const presetValue = presetArg ? presetArg.split("=")[1] : null;
+
+if (!presetValue) {
+    // print help
+    console.error("Usage: context-mcp --preset=<preset>");
+    console.error("Available presets:");
+    Presets.forEach((p) => {
+        console.error(`  ${p.name}: ${p.description}`);
+    });
+    process.exit(1);
+}
+
+const preset = Presets.find((p) => p.name === presetValue);
+if (!preset) {
+    console.error("Invalid preset:", presetValue);
+    process.exit(1);
+}
+
 console.error("Starting MCP server...");
 console.error("Version:", PKG.version);
 
@@ -11,6 +33,9 @@ const server = new MCPServer({
     name: "autodev-context-mcp",
     version: PKG.version,
 });
+
+console.error("Loading preset:", preset.name);
+server.loadPreset(preset);
 
 console.error("Server created, starting stdio...");
 

--- a/packages/context-mcp/src/_typing.ts
+++ b/packages/context-mcp/src/_typing.ts
@@ -1,0 +1,16 @@
+export const Presets = [
+    {
+        name: "SafePosix",
+        description: "SafePosix provides common posix commands as tools",
+    },
+    {
+        name: "DevOps",
+        description: "DevOps provides common devops commands as tools",
+    },
+    {
+        name: "AutoDev",
+        description: "AutoDev provides common auto dev commands as tools",
+    }
+] as const;
+
+export type Preset = (typeof Presets)[number]["name"];

--- a/packages/context-mcp/src/capabilities.ts
+++ b/packages/context-mcp/src/capabilities.ts
@@ -1,14 +1,27 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { prompts } from "./capabilities/prompts.js";
-import { tools } from "./capabilities/tools.js";
+import { AutoDevTools, DevOpsTools, PosixTools } from "./capabilities/tools.js";
 import { resources } from "./capabilities/resources.js";
 
 import type { ResourceMetadata } from "./capabilities/resources/_typing.js";
+import type { Preset } from "./_typing.js";
 
-// TODO: This metadata is really annoying, we should find a better way to do this.
-export function installCapabilities(mcpInst: McpServer, metadata: ResourceMetadata) {
+export function installCapabilities(mcpInst: McpServer, metadata: ResourceMetadata, preset: Preset) {
     resources.forEach(resource => resource(mcpInst.resource.bind(mcpInst), metadata));
-    tools.forEach(tool => tool(mcpInst.tool.bind(mcpInst)));
     prompts.forEach(prompt => prompt(mcpInst.prompt.bind(mcpInst)));
+
+    switch (preset) {
+        case "AutoDev":
+            AutoDevTools.forEach(tool => tool(mcpInst.tool.bind(mcpInst)));
+            break;
+        case "DevOps":
+            DevOpsTools.forEach(tool => tool(mcpInst.tool.bind(mcpInst)));
+            break;
+        case "SafePosix":
+            PosixTools.forEach(tool => tool(mcpInst.tool.bind(mcpInst)));
+            break;
+        default:
+            throw new Error(`Unsupported preset: ${preset}`);
+    }
 }

--- a/packages/context-mcp/src/capabilities/tools.ts
+++ b/packages/context-mcp/src/capabilities/tools.ts
@@ -1,5 +1,14 @@
-import { ToolLike } from "./tools/_typing.js";
 import { installAddTool } from "./tools/add.js";
+export const AddTools = [
+    installAddTool,
+] as const;
+
+import { installGetProjectContextTool } from "./tools/project/get-project-context.js";
+import { installResolveProjectTool } from "./tools/project/resolve-project.js";
+export const AutoDevTools = [
+    installGetProjectContextTool,
+    installResolveProjectTool,
+] as const;
 
 import { installGithubPrListTool } from "./tools/repo/github-pr-list.js";
 import { installGithubPrCreateTool } from "./tools/repo/github-pr-create.js";
@@ -7,6 +16,14 @@ import { installGitlabMrCreateTool } from "./tools/repo/gitlab-mr-create.js";
 import { installGitlabMrListTool } from "./tools/repo/gitlab-mr-list.js";
 import { installGitlabMrUpdateTool } from "./tools/repo/gitlab-mr-update.js";
 import { installGitlabMrCommentTool } from "./tools/repo/gitlab-mr-comment.js";
+export const DevOpsTools = [
+    installGithubPrListTool,
+    installGithubPrCreateTool,
+    installGitlabMrCreateTool,
+    installGitlabMrListTool,
+    installGitlabMrUpdateTool,
+    installGitlabMrCommentTool,
+] as const;
 
 import { installLsTool } from "./tools/sys/posix/ls.js";
 import { installCatTool } from "./tools/sys/posix/cat.js";
@@ -22,22 +39,9 @@ import { installFreeTool } from "./tools/sys/posix/free.js";
 import { installDfTool } from "./tools/sys/posix/df.js";
 import { installFindTool } from "./tools/sys/posix/find.js";
 import { installWcTool } from "./tools/sys/posix/wc.js";
-
 import { installAstGrepTool } from "./tools/sys/ast_grep.js";
 import { installRipGrepTool } from "./tools/sys/rip_grep.js";
-
-export const tools: ToolLike[] = [
-    installAddTool,
-
-    // Repo Platform Tools
-    installGithubPrCreateTool,
-    installGithubPrListTool,
-    installGitlabMrCreateTool,
-    installGitlabMrListTool,
-    installGitlabMrUpdateTool,
-    installGitlabMrCommentTool,
-
-    // POSIX tools
+export const PosixTools = [
     installLsTool,
     installCatTool,
     installGrepTool,
@@ -52,8 +56,6 @@ export const tools: ToolLike[] = [
     installDfTool,
     installFindTool,
     installWcTool,
-
-    // Code search tools
     installAstGrepTool,
     installRipGrepTool,
-];  
+] as const;

--- a/packages/context-mcp/src/capabilities/tools/project/get-project-context.ts
+++ b/packages/context-mcp/src/capabilities/tools/project/get-project-context.ts
@@ -1,6 +1,6 @@
 import { ToolLike } from "../_typing.js";
 
-export const getProjectContext: ToolLike = (installer) => {
+export const installGetProjectContextTool: ToolLike = (installer) => {
   installer(
     "get-project-context",
     "Get the context of a project",

--- a/packages/context-mcp/src/capabilities/tools/project/resolve-project.ts
+++ b/packages/context-mcp/src/capabilities/tools/project/resolve-project.ts
@@ -2,7 +2,7 @@ import { ToolLike } from "../_typing.js";
 
 import { z } from "zod";
 
-export const resolveProject: ToolLike = (installer) => {
+export const installResolveProjectTool: ToolLike = (installer) => {
   installer(
     "resolve-project",
     "Resolve a project from a given path",


### PR DESCRIPTION
Introduce preset loading in the MCP server CLI to enable configurable
tool sets. Update the server to accept and apply presets at startup,
improving flexibility and usability.

Refactor tools exports into categorized const arrays (AddTools,
AutoDevTools, DevOpsTools, PosixTools) for better modularity and
maintenance.

Update README to include the new --preset=AutoDev argument for easier
preset usage during development.