### PR TITLE
test(context-mcp): load "AutoDev" preset in server tests

### DIFF
--- a/packages/context-mcp/src/__tests__/server.test.ts
+++ b/packages/context-mcp/src/__tests__/server.test.ts
@@ -17,6 +17,7 @@ describe('MCPServerImpl', () => {
 
   beforeEach(() => {
     server = new MCPServerImpl(mockImpl);
+    server.loadPreset("AutoDev");
   });
 
   afterEach(async () => {

--- a/packages/context-mcp/src/server.ts
+++ b/packages/context-mcp/src/server.ts
@@ -100,7 +100,7 @@ export class MCPServerImpl {
 
   loadPreset(preset: Preset) {
     this.preset = preset;
-    installCapabilities(this.mcpInst, this.impl);
+    installCapabilities(this.mcpInst, this.impl, preset);
   }
 
   async serveHttp(options: HttpServeOptions) : Promise<http.Server> {


### PR DESCRIPTION
- Load the "AutoDev" preset before each server test for consistent setup  
- Update loadPreset method to pass the preset to installCapabilities  
- Enable capability installation to respect the selected preset configuration